### PR TITLE
Update 01:_Canadian_public_bodies.trset

### DIFF
--- a/01:_Canadian_public_bodies.trset
+++ b/01:_Canadian_public_bodies.trset
@@ -58,7 +58,13 @@ host nunavuttenders.ca
 host gov.pe.ca
 host opportunitiespei.ca
 host gc.ca
+host quebec.ca
+host gouv.qc.ca
+host msss.gouv.qc.ca
 host revenuquebec.ca
+host saaq.gouv.qc.ca
+host securitepublique.gouv.qc.ca
+host sq.gouv.qc.ca
 host gov.sk.ca
 host saskatchewan.ca
 host saskimmigrationcanada.ca


### PR DESCRIPTION
Added the following host in Quebec:

host quebec.ca
host gouv.qc.ca
host msss.gouv.qc.ca
host saaq.gouv.qc.ca
host securitepublique.gouv.qc.ca
host sq.gouv.qc.ca